### PR TITLE
failing test for non-existent attribute sets property to null

### DIFF
--- a/src/from-attribute-test.js
+++ b/src/from-attribute-test.js
@@ -27,3 +27,28 @@ QUnit.test("setting attribute will set property", function(assert) {
 	});
 });
 
+QUnit.test("property does not get set if the attribute does not exist", function(assert) {
+	assert.expect(1);
+	const done = assert.async();
+
+	fixture.innerHTML = "<div id='attr-prop-nexist'></div>";
+	const el = document.getElementById("attr-prop-nexist");
+
+	Object.defineProperty(el, 'lname', {
+		set (v) {
+			console.log(v);
+			assert.ok(false, "Should not be called as attribute does not exist");
+			return v;
+		}
+	});
+
+	const bindFn = fromAttribute('lname');
+	const binding = bindFn(el);
+	binding.start();
+
+	testHelpers.afterMutation(() => {
+		assert.equal(el.lname, undefined, "Should be undefined by default");
+		done();
+	});
+});
+

--- a/src/from-attribute.js
+++ b/src/from-attribute.js
@@ -112,19 +112,12 @@ module.exports = function fromAttribute (propertyName) {
 		});
 
 		// This is to prevent canReflect from reading the parent value and setting the child
-		// when the parent / instance doesn't isn't an attribute
-		const oldStart = bind.start;
-		bind.start = function () {
-			// Don't update the child if the attribute does not exist
-			const origUpdateChild = this._updateChild;
-			// create a noop
-			this._updateChild = function() {
-				if (instance.hasAttribute(propertyName)) {
-					origUpdateChild.apply(this, arguments);
-				}
-			};
-
-			oldStart.apply(this, arguments);
+		// when the parent / instance doesn't have an attribute
+		const origUpdateChild = bind._updateChild;
+		bind._updateChild = function() {
+			if (instance.hasAttribute(propertyName)) {
+				origUpdateChild.apply(this, arguments);
+			}
 		};
 
 		return bind;


### PR DESCRIPTION
This is a failing test to show that a non-existent attribute causes the property to be called with null.

Closes https://github.com/canjs/can-observable-bindings/issues/1