### PR TITLE
Prevent property being set twice during initialization

### DIFF
--- a/src/from-attribute-test.js
+++ b/src/from-attribute-test.js
@@ -1,7 +1,12 @@
 const QUnit = require("steal-qunit");
 const fromAttribute = require("./from-attribute");
 
-QUnit.module("can-observable-bindings - from-attribute");
+let fixture;
+QUnit.module("can-observable-bindings - from-attribute", {
+	beforeEach() {
+		fixture = document.querySelector("#qunit-fixture");
+	}
+});
 
 QUnit.test("setting attribute will set property", function (assert) {
 	const attributes = ["fname", "lname", "city"];
@@ -26,7 +31,8 @@ QUnit.test("setting attribute will set property", function (assert) {
 	};
 	
 	customElements.define("my-el", MyEl);
-	const el = new MyEl();
+	const el = document.createElement("my-el");
+	fixture.appendChild(el);
 
 	bindings.forEach(bindFn => {
 		const binding = bindFn(el);
@@ -60,38 +66,13 @@ QUnit.test("Does not set properties when attributes do not exist", function (ass
 	});
 	
 	customElements.define("my-el-1", MyEl);
-	const el = new MyEl();
-
-	bindings.forEach(bindFn => {
-		const binding = bindFn(el);
-		binding.start();
-	});
-
-	assert.equal(el.fname, undefined, "Setting attribute sets a property");
-});
-
-QUnit.test("Will initialize property when attribute exists", function (assert) {
-	const attributes = ["fname"];
-	const bindings = [];
-	class MyEl extends HTMLElement {
-		static get observedAttributes () {
-			return attributes;
-		}
-	}
-
-	attributes.forEach(attribute => {
-		const ctrBinding = fromAttribute(attribute);
-		bindings.push(ctrBinding(MyEl));
-	});
+	const el = document.createElement("my-el-1");
+	fixture.appendChild(el);
 	
-	customElements.define("my-el-2", MyEl);
-	const el = new MyEl();
-	el.setAttribute("fname", "Matt");
-
 	bindings.forEach(bindFn => {
 		const binding = bindFn(el);
 		binding.start();
 	});
 
-	assert.equal(el.fname, "Matt", "Sets property on initialization");
+	assert.strictEqual(el.fname, undefined, "Property not set");
 });

--- a/src/from-attribute.js
+++ b/src/from-attribute.js
@@ -48,14 +48,12 @@ module.exports = function fromAttribute (propertyName) {
 			// Child binding used by `attributeChangedCallback` to update the value when an attribute change occurs 
 			const childValue = value.to(instance, propertyName);
 			const bind = new Bind({
-				parent: value.from(instance.getAttribute(propertyName)),
+				parent: value.from(instance.getAttribute(propertyName) || undefined),
 				child: childValue,
 				queue: "dom",
-				setChild (newVal) {
-					// During initialization prevent update of child when parent attribute does not exist
-					if (instance.hasAttribute(propertyName)) {
-						canReflect.setValue(childValue, newVal);
-					}
+				setChild () {
+					// During initialization prevent update of child
+					// Initial value is read during initialization
 				}
 			});
 

--- a/src/from-attribute.js
+++ b/src/from-attribute.js
@@ -51,10 +51,8 @@ module.exports = function fromAttribute (propertyName) {
 				parent: value.from(instance.getAttribute(propertyName) || undefined),
 				child: childValue,
 				queue: "dom",
-				setChild () {
-					// During initialization prevent update of child
-					// Initial value is read during initialization
-				}
+				// During initialization prevent update of child
+				onInitDoNotUpdateChild: true
 			});
 
 			if (instance[metaSymbol] === undefined) {


### PR DESCRIPTION
Property is set within StacheElement  during binding initialization and was then being set through `can-bind`.

Removed test for setting property during initialization as this is handled within `StacheElement`