### PR TITLE
Update fromAttribute to import from core instead of `everything`

### DIFF
--- a/doc/from-attribute.md
+++ b/doc/from-attribute.md
@@ -11,7 +11,7 @@
   <my-el name="Matt"></my-el>
 
   <script type="module">
-  import { StacheElement, fromAttribute } from "can/everything";
+  import { fromAttribute, StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  static view = `


### PR DESCRIPTION
can-observable-bindings is part of the infrastructure collection so the `everything` module isn’t needed.