### PR TITLE
Adds the ability to pass a conversion object like JSON

### DIFF
--- a/from-attribute-test.js
+++ b/from-attribute-test.js
@@ -169,7 +169,7 @@ if (browserSupports.customElements) {
 		assert.strictEqual(el.age, 13, "Property is converted");
 	});
 
-	QUnit.test("Pass a converter", function(assert) {
+	QUnit.test("Can pass a converter", function(assert) {
 		const attributes = ['info'];
 		const bindings = [];
 
@@ -199,7 +199,7 @@ if (browserSupports.customElements) {
 		assert.deepEqual(el.info, {foo: "bar"}, "JSON is converted to object");
 	});
 
-	QUnit.test("Pass an attribute name and a converter", function(assert) {
+	QUnit.test("Can pass an attribute name and a converter", function(assert) {
 		const attributes = ['info'];
 		const bindings = [];
 
@@ -226,6 +226,57 @@ if (browserSupports.customElements) {
 		});
 
 		el.setAttribute('info', '{"foo": "bar"}');
+		assert.deepEqual(el.info, {foo: "bar"}, "JSON is converted to object");
+	});
+
+	QUnit.test("Throws an error when the converter is not valid", function(assert) {
+		const attributes = ['info'];
+		const bindings = [];
+
+		class MyEl extends HTMLElement {
+			static get observedAttributes() {
+				return attributes;
+			}
+		}
+
+		attributes.forEach(attribute => {
+			try {
+				const makeFromAttribute = fromAttribute(attribute, {});
+				bindings.push(makeFromAttribute(attribute, MyEl));
+				assert.ok(true);
+			} catch (e) {
+				assert.ok(true, 'Throws when the wrong object converter is passed');
+			}
+		});
+	});
+
+	QUnit.test("Works correctly if attribute is different from the attribute passed in setAttribute.", function(assert) {
+		const attributes = ['info'];
+		const bindings = [];
+
+		class MyEl extends HTMLElement {
+			static get observedAttributes() {
+				return ['my-attr'];
+			}
+		}
+
+		attributes.forEach(attribute => {
+			const makeFromAttribute = fromAttribute('my-attr', JSON);
+			bindings.push(makeFromAttribute(attribute, MyEl));
+		});
+
+		customElements.define('my-el-6', MyEl);
+		const el = document.createElement('my-el-6');
+		fixture.appendChild(el);
+
+		fixture.appendChild(el);
+
+		bindings.forEach(bindFn => {
+			const binding = bindFn(el);
+			binding.start();
+		});
+
+		el.setAttribute('my-attr', '{"foo": "bar"}');
 		assert.deepEqual(el.info, {foo: "bar"}, "JSON is converted to object");
 	});
 }

--- a/from-attribute-test.js
+++ b/from-attribute-test.js
@@ -168,4 +168,64 @@ if (browserSupports.customElements) {
 
 		assert.strictEqual(el.age, 13, "Property is converted");
 	});
+
+	QUnit.test("Pass a converter", function(assert) {
+		const attributes = ['info'];
+		const bindings = [];
+
+		class MyEl extends HTMLElement {
+			static get observedAttributes() {
+				return attributes;
+			}
+		}
+
+		attributes.forEach(attribute => {
+			const makeFromAttribute = fromAttribute(JSON);
+			bindings.push(makeFromAttribute(attribute,MyEl));
+		});
+
+		customElements.define('my-el-4', MyEl);
+		const el = document.createElement('my-el-4');
+		fixture.appendChild(el);
+
+		fixture.appendChild(el);
+
+		bindings.forEach(bindFn => {
+			const binding = bindFn(el);
+			binding.start();
+		});
+
+		el.setAttribute('info', '{"foo": "bar"}');
+		assert.deepEqual(el.info, {foo: "bar"}, "JSON is converted to object");
+	});
+
+	QUnit.test("Pass an attribute name and a converter", function(assert) {
+		const attributes = ['info'];
+		const bindings = [];
+
+		class MyEl extends HTMLElement {
+			static get observedAttributes() {
+				return attributes;
+			}
+		}
+
+		attributes.forEach(attribute => {
+			const makeFromAttribute = fromAttribute(attribute, JSON);
+			bindings.push(makeFromAttribute(attribute, MyEl));
+		});
+
+		customElements.define('my-el-5', MyEl);
+		const el = document.createElement('my-el-5');
+		fixture.appendChild(el);
+
+		fixture.appendChild(el);
+
+		bindings.forEach(bindFn => {
+			const binding = bindFn(el);
+			binding.start();
+		});
+
+		el.setAttribute('info', '{"foo": "bar"}');
+		assert.deepEqual(el.info, {foo: "bar"}, "JSON is converted to object");
+	});
 }

--- a/from-attribute.js
+++ b/from-attribute.js
@@ -150,14 +150,12 @@ module.exports = function fromAttribute (attributeName, ctr) {
 	// Handle the class constructor
 	if (arguments.length === 2 && !isJSONLike(ctr)) {
 		return initializeFromAttribute(attributeName, ctr);
-	} else if (ctr && isJSONLike(ctr)) {
-		// Handle attribute name is passed with JSON like object
-		var converter = ctr;
-		return function (propertyName, ctr) {
-			return initializeFromAttribute(propertyName, ctr, converter);
-		};
-
 	} else {
+		if (ctr && isJSONLike(ctr)) {
+			// Handle the case where an attribute name 
+			// and JSON like converter is passed
+			attributeName = ctr;
+		}
 		return function (propertyName, ctr) {
 			return initializeFromAttribute(propertyName, ctr, attributeName);
 		};


### PR DESCRIPTION
Fixes #11 

Make it possible to pass a JSON like conversion object:

`person: { type: Object, bind: fromAttribute( JSON ) }`

or:

`person: { type: Object, bind: fromAttribute( 'attr-name',  JSON ) }`